### PR TITLE
implemented bare bones nearbysearch api

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-scalars:2.7.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
     implementation 'com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.1'

--- a/app/src/main/java/com/example/snaplapse/api/MapHelper.kt
+++ b/app/src/main/java/com/example/snaplapse/api/MapHelper.kt
@@ -1,0 +1,26 @@
+package com.example.snaplapse.api
+
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.converter.scalars.ScalarsConverterFactory
+
+object MapHelper {
+
+    private const val baseUrl="https://maps.googleapis.com/"
+
+    fun getInstance(): Retrofit {
+
+        var mHttpLoggingInterceptor = HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY)
+
+        var mOkHttpClient = OkHttpClient.Builder().addInterceptor(mHttpLoggingInterceptor).build()
+
+        return Retrofit.Builder().baseUrl(MapHelper.baseUrl)
+            .addConverterFactory(ScalarsConverterFactory.create())
+            .client(mOkHttpClient)
+            // we need to add converter factory to
+            // convert JSON object to Java object
+            .build()
+    }
+}

--- a/app/src/main/java/com/example/snaplapse/api/routes/MapsApi.kt
+++ b/app/src/main/java/com/example/snaplapse/api/routes/MapsApi.kt
@@ -1,0 +1,10 @@
+package com.example.snaplapse.api.routes
+
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.QueryMap
+
+interface MapsApi {
+    @GET("/maps/api/place/nearbysearch/json")
+    suspend fun getNearbyPlaces(@QueryMap params: Map<String, String>): Response<String>
+}

--- a/app/src/main/java/com/example/snaplapse/camera/PhotoEditFragment.kt
+++ b/app/src/main/java/com/example/snaplapse/camera/PhotoEditFragment.kt
@@ -1,8 +1,11 @@
 package com.example.snaplapse.camera
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.pm.PackageManager
 import android.graphics.Bitmap
+import android.location.Location
 import android.os.Bundle
 import android.util.Base64
 import android.util.Log
@@ -12,16 +15,26 @@ import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
+import com.example.snaplapse.BuildConfig
 import com.example.snaplapse.R
+import com.example.snaplapse.api.MapHelper
 import com.example.snaplapse.api.RetrofitHelper
 import com.example.snaplapse.api.data.photo.PhotoRequest
+import com.example.snaplapse.api.routes.MapsApi
 import com.example.snaplapse.api.routes.PhotosApi
 import com.example.snaplapse.databinding.FragmentPhotoEditBinding
+import com.example.snaplapse.map.MapFragment
 import com.example.snaplapse.view_models.CameraViewModel
 import com.example.snaplapse.view_models.ItemsViewModel2
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.LatLng
 import java.io.ByteArrayOutputStream
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -33,6 +46,11 @@ class PhotoEditFragment : Fragment() {
     private val binding get() = _binding
 
     private val viewModel: CameraViewModel by activityViewModels()
+
+    private var locationPermissionGranted = false
+    private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
+    private var lastKnownLocation: Location? = null
+    private var coordString: String = ""
 
     private lateinit var imageBitmap: Bitmap
 
@@ -57,6 +75,11 @@ class PhotoEditFragment : Fragment() {
             }
         }
 
+        fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(safeContext)
+
+        getLocationPermission()
+        getDeviceLocation()
+
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, callback)
         _binding = FragmentPhotoEditBinding.inflate(inflater, container, false)
         return binding.root
@@ -73,6 +96,23 @@ class PhotoEditFragment : Fragment() {
     }
 
     private fun uploadPhoto() {
+        var params: MutableMap<String, String> = mutableMapOf<String, String>()
+        params["location"] = coordString
+        params["radius"] = "1000"
+        params["key"] = BuildConfig.MAPS_API_KEY
+
+        lifecycleScope.launchWhenCreated {
+            try {
+                val response = MapHelper.getInstance().create(MapsApi::class.java).getNearbyPlaces(params)
+                if (response.isSuccessful) {
+                    Log.i("resp", response.body().toString())
+                }
+            } catch (e: Exception) {
+                Log.e("NearbyPlacesError", e.toString())
+            }
+        }
+
+
         val description = binding.textInput.text.toString()
         if (description.isBlank()) {
             Toast.makeText(safeContext, "Please provide a description.", Toast.LENGTH_SHORT).show()
@@ -89,6 +129,60 @@ class PhotoEditFragment : Fragment() {
         val transaction = parentFragmentManager.beginTransaction()
         transaction.add(R.id.fragmentContainerView, CameraFragment())
         transaction.commit()
+    }
+
+    private fun getLocationPermission() {
+        /*
+         * Request location permission, so that we can get the location of the
+         * device. The result of the permission request is handled by a callback,
+         * onRequestPermissionsResult.
+         */
+        if (ContextCompat.checkSelfPermission(safeContext,
+                Manifest.permission.ACCESS_FINE_LOCATION)
+            == PackageManager.PERMISSION_GRANTED) {
+            locationPermissionGranted = true
+        } else {
+            ActivityCompat.requestPermissions(requireActivity(), arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
+                PERMISSIONS_REQUEST_ACCESS_FINE_LOCATION
+            )
+        }
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int,
+                                            permissions: Array<String>,
+                                            grantResults: IntArray) {
+        locationPermissionGranted = false
+        when (requestCode) {
+            PERMISSIONS_REQUEST_ACCESS_FINE_LOCATION -> {
+                if (grantResults.isNotEmpty() &&
+                    grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    locationPermissionGranted = true
+                }
+            }
+            else -> super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun getDeviceLocation() {
+        /*
+         * Get the best and most recent location of the device, which may be null in rare
+         * cases when a location is not available.
+         */
+        if (locationPermissionGranted) {
+            val locationResult = fusedLocationProviderClient.lastLocation
+            locationResult.addOnCompleteListener(requireActivity()) { task ->
+                if (task.isSuccessful) {
+                    lastKnownLocation = task.result
+                    if (lastKnownLocation != null) {
+                        val sb = StringBuilder()
+                        sb.append(lastKnownLocation!!.latitude.toString()).append(",").append(lastKnownLocation!!.longitude.toString())
+                        coordString = sb.toString()
+                    }
+                } else {
+                }
+            }
+        }
     }
 
     @SuppressLint("NewApi")
@@ -121,5 +215,14 @@ class PhotoEditFragment : Fragment() {
                 Log.e("UploadPhotoError", e.toString())
             }
         }
+    }
+
+    companion object {
+        private const val DEFAULT_ZOOM = 15
+        private const val PERMISSIONS_REQUEST_ACCESS_FINE_LOCATION = 1
+
+        // Keys for storing activity state.
+        private const val KEY_CAMERA_POSITION = "camera_position"
+        private const val KEY_LOCATION = "location"
     }
 }


### PR DESCRIPTION
A very bare bones implementation of the nearbysearch api
Nearbysearch will be called when you try to upload a photo (would recommend trying to upload a photo without a description so that you don't leave the fragment)
Takes the current device's location (lat,long), a radius and the maps api key as parameters, and returns (as a string for now) the nearby locations

Example:  https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=37.4219983,-122.084&radius=1000&key=key

The response also contains a next_page_token as the results are paginated, this token will allow you to see more results

Example: https://maps.googleapis.com/maps/api/place/nearbysearch/json?pagetoken=CpQCAgEAAFxg8o-eU7_uKn7Yqjana-HQIx1hr5BrT4zBaEko29ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk-ReY7oulyuvKSQrw1lgJElggGlo0d6indiH1U-tDwquw4tU_UXoQ_sj8OBo8XBUuWjuuFShqmLMP-0W59Vr6CaXdLrF8M3wFR4dUUhSf5UC4QCLaOMVP92lyh0OdtF_m_9Dt7lz-Wniod9zDrHeDsz_by570K3jL1VuDKTl_U1cJ0mzz_zDHGfOUf7VU1kVIs1WnM9SGvnm8YZURLTtMLMWx8-doGUE56Af_VfKjGDYW361OOIj9GmkyCFtaoCmTMIr5kgyeUSnB-IEhDlzujVrV6O9Mt7N4DagR6RGhT3g1viYLS4kO5YindU6dm3GIof1Q&key=key

I copy pasted a lot of code from the map fragment to make this work (will refactor it later). As it stands, this code isn't good enough to stay in the final version but it functions well enough for anyone that needs to work with locations. Hoping to merge after approval so that we can speed run these last few days.