### PR TITLE
created ability to spoof your location

### DIFF
--- a/app/src/main/java/com/example/snaplapse/camera/CameraFragment.kt
+++ b/app/src/main/java/com/example/snaplapse/camera/CameraFragment.kt
@@ -2,12 +2,15 @@ package com.example.snaplapse.camera
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.ProgressDialog.show
 import android.content.Context
+import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -19,8 +22,11 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import com.example.snaplapse.BuildConfig
 import com.example.snaplapse.R
+import com.example.snaplapse.api.MapHelper
+import com.example.snaplapse.api.routes.MapsApi
 import com.example.snaplapse.databinding.FragmentCameraBinding
 import com.example.snaplapse.view_models.CameraViewModel
 import com.example.snaplapse.view_models.CurrentPlaceViewModel
@@ -30,6 +36,7 @@ import com.google.android.libraries.places.api.net.FindCurrentPlaceRequest
 import com.google.android.libraries.places.api.net.PlacesClient
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import org.json.JSONObject
 
 class CameraFragment : Fragment() {
     private lateinit var safeContext: Context
@@ -45,6 +52,7 @@ class CameraFragment : Fragment() {
     private lateinit var cameraExecutor: ExecutorService
     private lateinit var placesClient: PlacesClient
     private var locationPermissionGranted = false
+    private var sharedPref: SharedPreferences? = null
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -77,6 +85,8 @@ class CameraFragment : Fragment() {
             }
             requestMultiplePermissions.launch(REQUIRED_PERMISSIONS)
         }
+        sharedPref = activity?.getSharedPreferences(getString(R.string.preferences_file_key), Context.MODE_PRIVATE)
+        binding.spoofButton.setOnClickListener { SpoofDialogFragment().show(childFragmentManager, "")}
         binding.shutterButton.setOnClickListener { takePhoto() }
         cameraExecutor = Executors.newSingleThreadExecutor()
     }
@@ -125,32 +135,87 @@ class CameraFragment : Fragment() {
                 )
                 viewModel.setImageBitmap(imageBitmap)
 
-                if (locationPermissionGranted) {
-                    Places.initialize(safeContext, BuildConfig.MAPS_API_KEY)
-                    placesClient = Places.createClient(safeContext)
+                if (sharedPref!!.contains("latitude") && sharedPref!!.contains("longitude")) {
+                    lifecycleScope.launchWhenCreated {
+                        try {
+                            val sb = StringBuilder()
+                            sb.append(sharedPref?.getFloat("latitude", 0F)).append(",").append(sharedPref?.getFloat("longitude", 0F))
 
-                    // Use fields to define the data types to return.
-                    val placeFields = listOf(Place.Field.NAME, Place.Field.ADDRESS, Place.Field.LAT_LNG, Place.Field.TYPES, Place.Field.ID)
+                            val params = HashMap<String, String>()
+                            params["key"] = BuildConfig.MAPS_API_KEY
+                            params["location"] = sb.toString()
+                            params["rankby"] = "distance"
 
-                    // Use the builder to create a FindCurrentPlaceRequest.
-                    val request = FindCurrentPlaceRequest.newInstance(placeFields)
+                            val mapsResponse = MapHelper.getInstance().create(MapsApi::class.java).getNearbyPlaces(params)
+                            if (mapsResponse.isSuccessful) {
+                                val json = JSONObject(mapsResponse.body().toString())
+                                val likelyPlace = JSONObject(json.getJSONArray("results")[0].toString())
 
-                    // Get the likely places - that is, the businesses and other points of interest that
-                    // are the best match for the device's current location.
-                    val placeResult = placesClient.findCurrentPlace(request)
-                    placeResult.addOnCompleteListener { task ->
-                        if (task.isSuccessful && task.result != null) {
-                            val likelyPlace = task.result.placeLikelihoods[0].place
-                            val transaction = parentFragmentManager.beginTransaction()
-                            transaction.add(R.id.fragmentContainerView,
-                                PhotoEditFragment(CurrentPlaceViewModel(likelyPlace.name, likelyPlace.address, likelyPlace.id, likelyPlace.latLng.latitude, likelyPlace.latLng.longitude, likelyPlace.types))
-                            )
-                            transaction.commit()
-                            image.close()
+                                val types = ArrayList<String>()
+                                for (i in 0 until likelyPlace.getJSONArray("types").length()) {
+                                    types.add(likelyPlace.getJSONArray("types")[i].toString())
+                                }
+
+                                val transaction = parentFragmentManager.beginTransaction()
+                                transaction.add(R.id.fragmentContainerView,
+                                    PhotoEditFragment(CurrentPlaceViewModel
+                                        (
+                                            likelyPlace.getString("name"),
+                                            likelyPlace.getString("vicinity"),
+                                            likelyPlace.getString("place_id"),
+                                            likelyPlace.getJSONObject("geometry").getJSONObject("location").getDouble("lat"),
+                                            likelyPlace.getJSONObject("geometry").getJSONObject("location").getDouble("lng"),
+                                            types
+                                        )
+                                    )
+                                )
+                                transaction.commit()
+                                image.close()
+                            }
+                            else {
+                                Log.i("mapsResponseError", "")
+                            }
+
+                        } catch (e: Exception) {
+                            Log.i("NearbySearchError", e.toString())
                         }
                     }
-                } else {
-                    getLocationPermission()
+                }
+                else {
+                    if (locationPermissionGranted) {
+                        Places.initialize(safeContext, BuildConfig.MAPS_API_KEY)
+                        placesClient = Places.createClient(safeContext)
+
+                        // Use fields to define the data types to return.
+                        val placeFields = listOf(Place.Field.NAME, Place.Field.ADDRESS, Place.Field.LAT_LNG, Place.Field.TYPES, Place.Field.ID)
+
+                        // Use the builder to create a FindCurrentPlaceRequest.
+                        val request = FindCurrentPlaceRequest.newInstance(placeFields)
+
+                        // Get the likely places - that is, the businesses and other points of interest that
+                        // are the best match for the device's current location.
+
+                        val placeResult = placesClient.findCurrentPlace(request)
+                        placeResult.addOnCompleteListener { task ->
+                            if (task.isSuccessful && task.result != null) {
+                                val likelyPlace = task.result.placeLikelihoods[0].place
+
+                                val types = ArrayList<String>()
+                                for (i in likelyPlace.types) {
+                                    types.add(i.toString())
+                                }
+
+                                val transaction = parentFragmentManager.beginTransaction()
+                                transaction.add(R.id.fragmentContainerView,
+                                    PhotoEditFragment(CurrentPlaceViewModel(likelyPlace.name, likelyPlace.address, likelyPlace.id, likelyPlace.latLng.latitude, likelyPlace.latLng.longitude, types))
+                                )
+                                transaction.commit()
+                                image.close()
+                            }
+                        }
+                    } else {
+                        getLocationPermission()
+                    }
                 }
             }
             override fun onError(exception: ImageCaptureException) {}

--- a/app/src/main/java/com/example/snaplapse/camera/PhotoEditFragment.kt
+++ b/app/src/main/java/com/example/snaplapse/camera/PhotoEditFragment.kt
@@ -118,18 +118,18 @@ class PhotoEditFragment(var currentPlaceViewModel: CurrentPlaceViewModel) : Frag
                     locationId = locationGetResponse.body()!!.id
                 }
                 else {
-                    val arrays: MutableList<Int> = ArrayList()
+                    val categories: MutableList<Int> = ArrayList()
                     for (item in currentPlaceViewModel.types) {
-                        val categoryGetResponse = categoriesApi.getCategoryByName(item.toString())
+                        val categoryGetResponse = categoriesApi.getCategoryByName(item)
                         if (categoryGetResponse.isSuccessful) {
-                            arrays.add(categoryGetResponse.body()!!.id)
+                            categories.add(categoryGetResponse.body()!!.id)
                         }
                         else {
                             if (categoryGetResponse.code() == 404) {
-                                val categoryRequestBody = CategoryRequest(name=item.toString())
+                                val categoryRequestBody = CategoryRequest(name=item)
                                 val categoryPostResponse = categoriesApi.createCategory(categoryRequestBody)
                                 if (categoryPostResponse.isSuccessful) {
-                                    arrays.add(categoryPostResponse.body()!!.id)
+                                    categories.add(categoryPostResponse.body()!!.id)
                                 }
                                 else {
                                     Log.i("CategoryPostError", "error")
@@ -141,7 +141,7 @@ class PhotoEditFragment(var currentPlaceViewModel: CurrentPlaceViewModel) : Frag
                         }
                     }
 
-                    val locationRequestBody = LocationRequest(name=currentPlaceViewModel.name, longitude=currentPlaceViewModel.longitude, latitude=currentPlaceViewModel.latitude, categories=arrays, google_id=currentPlaceViewModel.id)
+                    val locationRequestBody = LocationRequest(name=currentPlaceViewModel.name, longitude=currentPlaceViewModel.longitude, latitude=currentPlaceViewModel.latitude, categories=categories, google_id=currentPlaceViewModel.id)
                     val locationPostResponse = locationsApi.createLocation(locationRequestBody)
                     if (locationPostResponse.isSuccessful) {
                         locationId = locationPostResponse.body()!!.id

--- a/app/src/main/java/com/example/snaplapse/camera/SpoofDialogFragment.kt
+++ b/app/src/main/java/com/example/snaplapse/camera/SpoofDialogFragment.kt
@@ -1,0 +1,48 @@
+package com.example.snaplapse.camera
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.Context
+import android.content.DialogInterface
+import android.os.Bundle
+import android.util.Log
+import android.widget.EditText
+import androidx.fragment.app.DialogFragment
+import com.example.snaplapse.R
+
+class SpoofDialogFragment: DialogFragment() {
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return activity?.let {
+            val builder = AlertDialog.Builder(context)
+            val inflater = requireActivity().layoutInflater
+            val sharedPref = activity?.getSharedPreferences(getString(R.string.preferences_file_key), Context.MODE_PRIVATE)
+            val view = inflater.inflate(R.layout.fragment_spoof_dialog, null)
+
+            val latitudeText = view.findViewById<EditText>(R.id.setLatitude)
+            val longitudeText = view.findViewById<EditText>(R.id.setLongitude)
+
+            builder.setView(view)
+                .setTitle("Location Spoofing")
+
+                // Add action buttons
+                .setPositiveButton("Confirm",
+                    DialogInterface.OnClickListener { dialog, id ->
+                        with(sharedPref?.edit()) {
+                            this?.putFloat("latitude", latitudeText.text.toString().toFloat())
+                            this?.putFloat("longitude", longitudeText.text.toString().toFloat())
+                            this?.apply()
+                        }
+                    })
+                .setNegativeButton("Cancel",
+                    DialogInterface.OnClickListener { dialog, id ->
+                        with(sharedPref?.edit()) {
+                            this?.remove("latitude")
+                            this?.remove("longitude")
+                            this?.apply()
+                        }
+                    })
+
+            builder.create()
+        }  ?: throw IllegalStateException("Activity cannot be null")
+    }
+}

--- a/app/src/main/java/com/example/snaplapse/view_models/CurrentPlaceViewModel.kt
+++ b/app/src/main/java/com/example/snaplapse/view_models/CurrentPlaceViewModel.kt
@@ -8,5 +8,5 @@ data class CurrentPlaceViewModel(
     val id: String,
     val latitude: Double,
     val longitude: Double,
-    val types: List<Place.Type>
+    val types: List<String>
 )

--- a/app/src/main/res/layout/fragment_camera.xml
+++ b/app/src/main/res/layout/fragment_camera.xml
@@ -7,9 +7,9 @@
     tools:context=".camera.CameraFragment">
 
     <androidx.camera.view.PreviewView
+        android:id="@+id/viewFinder"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:id="@+id/viewFinder" />
+        android:layout_height="match_parent" />
 
     <Button
         android:id="@+id/shutterButton"
@@ -19,5 +19,14 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent" />
+
+    <Button
+        android:id="@+id/spoofButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/spoof_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/viewFinder" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_spoof_dialog.xml
+++ b/app/src/main/res/layout/fragment_spoof_dialog.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/setLatitude"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="Latitude"
+        android:inputType="textPersonName"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <EditText
+        android:id="@+id/setLongitude"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="Longitude"
+        android:inputType="textPersonName"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/setLatitude" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
 
     <!-- Camera -->
     <string name="shutter_button">Take Photo</string>
+    <string name="spoof_button">Spoof</string>
     <string name="upload_button">Upload</string>
     <string name="delete_button">Delete</string>
 


### PR DESCRIPTION
Another excuse to make the camera fragment uglier :D

There is now a button that will open a LocationSpoof Dialog and allow you to temporarily change your location. Enter a latitude and longitude (as floats) and when you take a photo the app will use Google's nearby search API to find the location nearest to your lat long coordinates. These coordinates will be saved into sharedPrefs when you tap Confirm in the dialog and will be removed when you tap Cancel.

If you're not trying to spoof your location, the current place API will be used instead.

Unlike current place, nearby search has some variances in their parameters.
Both use name, place_id, types
Current place uses an object<Double,Double> to represent their lat long. Nearby search uses a Geometry object, which contains a Location object, which contains the lat long.
Current place uses an address string to represent street address. Nearby search uses a vicinity string.

Note that for nearby search, every field in the response is optional meaning that there is a possibility that a place won't have vicinity, geometry, etc. which would cause issues.

In any case, please review as this will be helpful for testing other locations.

PS @Raymond-Xia When I was testing other locations I was able to confirm that multiple categories can be generated simultaneously.