### PR TITLE
Added quick loading to FYP and paginated all recs

### DIFF
--- a/app/src/main/java/com/example/snaplapse/api/routes/LocationsApi.kt
+++ b/app/src/main/java/com/example/snaplapse/api/routes/LocationsApi.kt
@@ -14,10 +14,13 @@ interface LocationsApi {
     suspend fun getLocation(@Path("id") id: Int?): Response<LocationResponse>
 
     @GET("/api/locations/recommendations")
-    suspend fun getRecommendations(@Query("userId") userId: Int,
-                                @Query("coordinates", encoded = true) coordinates: String,
-                                @Query("radius") radius: Int,
-                                @Query("count") count: Int): Response<LocationListResponse>
+    suspend fun getRecommendations(
+        @Query("userId") userId: Int,
+        @Query("coordinates", encoded = true) coordinates: String,
+        @Query("radius") radius: Int,
+        @Query("count") count: Int,
+        @Query("page") page: Int? = null
+    ): Response<LocationListResponse>
 
     @GET("/api/locations/googleId/{google_id}/")
     suspend fun getLocationByGoogleId(@Path("google_id") google_id: String): Response<LocationResponse>


### PR DESCRIPTION
it works trust
- FYP now instantly creates the layout when first 3 recommendations are retrieved so something is on screen faster, while the rest load in the background (~5 seconds now compared to ~10 seconds for all on emulator)
- Paginated all recommendations, otherwise we were only getting max 10